### PR TITLE
Remove printmoney variable

### DIFF
--- a/config-instructions.yml
+++ b/config-instructions.yml
@@ -8,7 +8,6 @@ general:
   vive-only-kickmessage: This server is configured for Vivecraft players only.
   #Ticks to wait before kicking a player. The player's client must send a Vivecraft VERSION info in that time.
   vive-only-kickwaittime: 100
-  printmoney: false
 SendPlayerData:
   #Send player data to all clients with Vivecraft
   enabled: true

--- a/config.yml
+++ b/config.yml
@@ -8,7 +8,6 @@ general:
   vive-only-kickmessage: This server is configured for Vivecraft players only.
   #Ticks to wait before kicking a player. The player's client must send a Vivecraft VERSION info in that time.
   vive-only-kickwaittime: 100
-  printmoney: false
 SendPlayerData:
   #Send player data to all clients with Vivecraft
   enabled: true


### PR DESCRIPTION
 The print statement it triggers was removed long ago, so it's now unused. Best to remove it to avoid confusion