### PR TITLE
Add more permissions (Fixes #50 & #40)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 VSE is a companion plugin for [Vivecraft](http://www.vivecraft.org), the VR mod for Java Minecraft. 
 VSE is for [Spigot](https://www.spigotmc.org/) servers and adds several enhancements for VR players.
 
-# Features
+## Features
  - Vivecraft players will see other Vivecraft players head and arm movements.
  - Support for Vivecraft 2-handed archery.
  - Assign permission groups for VR players.
@@ -12,7 +12,24 @@ VSE is for [Spigot](https://www.spigotmc.org/) servers and adds several enhancem
 
 See the config.yml for all available configuration options.
 
-#Installation
+## Installation
 Download from the [Releases](https://github.com/jrbudda/Vivecraft_Spigot_Extensions/releases) page. Please ensure you download the correct version of the plugin as they are not backwards compatible.
 
 Install as you would any other Spigot/Bukkit plugin by placing the jar in the /plugins folder. 
+
+## Permissions
+
+Permission                  | Default   | Description
+----------------------------|-----------|----------------------------------------------
+vive.use                    | true      | Whether or not to provide server integrations
+vive.climbanywhere          | op        | Permission to override climb limitations.
+vive.command.vive-only      | op        | Access to the /vse vive-only command
+vive.command.sendplayerdata | op        | Access to the /vse sendplayerdata command
+vive.command.creeperradius  | true      | Access to the /vse creeperradius command
+vive.command.waittime       | op        | Access to the /vse waittime command
+vive.command.bow            | op        | Access to the /vse bow command
+vive.command.list           | true      | Access to the /vse list command
+vive.command.set            | true      | Access to the /vse set command
+vive.command.version        | true      | Access to the /vse version command
+vive.command.checkforupdate | false     | Access to the /vse checkforupdate command
+vive.command.help           | true      | Access to the /vse help command

--- a/build.gradle
+++ b/build.gradle
@@ -13,12 +13,12 @@ repositories {
 	maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
 }
 
-ext.mcversion = '1.11.2'
+ext.mcversion = '1.13.2'
 version = '0.1'
 
 // In this section you declare the dependencies for your production and test code
 dependencies {
-	compile "org.spigotmc:spigot-api:1.11.2-R0.1-SNAPSHOT"
+	compile "org.spigotmc:spigot-api:1.13.2-R0.1-SNAPSHOT"
 	compile "net.milkbowl.vault:VaultAPI:1.6"
 	compile fileTree(dir: 'lib', include: '*.jar')
 }

--- a/config-instructions.yml
+++ b/config-instructions.yml
@@ -49,8 +49,6 @@ permissions:
   non-vivegroup: vive.non-vivegroup
   #Permission group for vive users in free move mode.
   freemovegroup: vive.freemovegroup
-  #Permission to override climb limitations.
-  climbperm: vive.climbanywhere
 welcomemsg:
   enabled: false
   #Remove message to not send or set to nothing. ex: leaveMessage:

--- a/config.yml
+++ b/config.yml
@@ -49,8 +49,6 @@ permissions:
   non-vivegroup: vive.non-vivegroup
   #Permission group for vive users in free move mode.
   freemovegroup: vive.freemovegroup
-  #Permission to override climb limitations.
-  climbperm: vive.climbanywhere
 welcomemsg:
   enabled: false
   #Remove message to not send or set to nothing. ex: leaveMessage:

--- a/plugin.yml
+++ b/plugin.yml
@@ -5,9 +5,45 @@ website: http://www.vivecraft.org/
 author: jrbudda, jaron780
 prefix: Vivecraft
 commands:
-   Vive:
-      description: Vivecraft Spigot Extensions
-      usage: /vive <command>
    vse:
+      aliases: [Vive]
       description: Vivecraft Spigot Extensions
-      usage: /vse <command>
+      usage: /<command> <command>
+permissions:
+   vive.use:
+      default: true
+      description: Whether or not to provide server integrations to that player
+   vive.climbanywhere:
+      default: op
+      description: Permission to override climb limitations.
+   vive.command.vive-only:
+      default: op
+      description: Access to the /vse vive-only command
+   vive.command.sendplayerdata:
+      default: op
+      description: Access to the /vse sendplayerdata command
+   vive.command.creeperradius:
+      default: true
+      description: Access to the /vse creeperradius command
+   vive.command.waittime:
+      default: op
+      description: Access to the /vse waittime command
+   vive.command.bow:
+      default: op
+      description: Access to the /vse bow command
+   vive.command.list:
+      default: true
+      description: Access to the /vse list command
+   vive.command.set:
+      default: true
+      description: Access to the /vse set command
+   vive.command.version:
+      default: true
+      description: Access to the /vse version command
+   vive.command.checkforupdate:
+      default: op
+      description: Access to the /vse checkforupdate command
+   vive.command.help:
+      default: true
+      description: Access to the /vse help command
+   

--- a/src/org/vivecraft/VSE.java
+++ b/src/org/vivecraft/VSE.java
@@ -134,10 +134,8 @@ public class VSE extends JavaPlugin implements Listener {
 		}
 					
 		// end Config part
-		
-		getCommand("vive").setExecutor(new ViveCommand(this));
+
 		getCommand("vse").setExecutor(new ViveCommand(this));
-		getCommand("vive").setTabCompleter(new ConstructTabCompleter());
 		getCommand("vse").setTabCompleter(new ConstructTabCompleter());
 
 		getServer().getMessenger().registerIncomingPluginChannel(this, CHANNEL, new VivecraftNetworkListener(this));

--- a/src/org/vivecraft/command/Cmd.java
+++ b/src/org/vivecraft/command/Cmd.java
@@ -23,4 +23,8 @@ public class Cmd {
 	public String getHoverText(){
 		return this.hovertext;
 	}
+
+	public String getPermission() {
+		return "vive.command." + cmd.toLowerCase();
+	}
 }

--- a/src/org/vivecraft/command/ConstructTabCompleter.java
+++ b/src/org/vivecraft/command/ConstructTabCompleter.java
@@ -15,9 +15,9 @@ public class ConstructTabCompleter implements TabCompleter {
 		List<String> list = new ArrayList<String>();
 		if(arg0 instanceof Player){
 			if(arg3.length >= 1){
-				for(Cmd cmd: ViveCommand.getCommands()){
-					if(cmd.getCommand().startsWith(arg3[0]))
-					list.add(cmd.getCommand());
+				for(Cmd cmd: ViveCommand.getCommands().values()){
+					if(cmd.getCommand().startsWith(arg3[0].toLowerCase()))
+						list.add(cmd.getCommand());
 				}
 				return list;
 			}

--- a/src/org/vivecraft/command/ViveCommand.java
+++ b/src/org/vivecraft/command/ViveCommand.java
@@ -1,7 +1,7 @@
 package org.vivecraft.command;
 
-import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 
@@ -21,34 +21,48 @@ import net.md_5.bungee.api.chat.TextComponent;
 public class ViveCommand implements CommandExecutor {
 
 	private VSE plugin;
-	private static ArrayList<Cmd> commands = new ArrayList<Cmd>();
+	private static Map<String, Cmd> commands = new LinkedHashMap<>();
 
 	public ViveCommand(VSE vse) {
 		plugin = vse;
-		commands.add(new Cmd("vive-only", "Set to true to only allow Vivecraft players to play. Default: false","Example: /vse vive-only true"));
-		commands.add(new Cmd("waittime","Ticks to wait before kicking a player. The player's client must send a Vivecraft VERSION info in that time. Default: 60","Example: /vse waittime 60"));
-		commands.add(new Cmd("version", "returns the version of the plugin.","Example: /vse version"));
-		commands.add(new Cmd("sendplayerdata", "set to false to disable sending player to data to clients. Default: true","Example: /vse sendplayerdata true"));
-		commands.add(new Cmd("creeperradius", "type false to disable or type a number to change the radius. Default: 1.75","Example: /vse creeperradius 1.75"));
-		commands.add(new Cmd("bow", "Sets the multiplier for bow damage of vive users. Default: 2","Example: /vse bow 2"));
-		commands.add(new Cmd("checkforupdate", "Checked for an update every time an OP joins the server","Example: /vse checkforupdate true"));
-		commands.add(new Cmd("set", "Allows Editing the plugin config ingame. May need to restart server to take effect.","Example: /vse set general.vive-only true"));
-		commands.add(new Cmd("list", "Lists all the users using Vivecraft.","Example: /vse list"));
+		addCommand(new Cmd("vive-only", "Set to true to only allow Vivecraft players to play. Default: false","Example: /vse vive-only true"));
+		addCommand(new Cmd("waittime","Ticks to wait before kicking a player. The player's client must send a Vivecraft VERSION info in that time. Default: 60","Example: /vse waittime 60"));
+		addCommand(new Cmd("version", "returns the version of the plugin.","Example: /vse version"));
+		addCommand(new Cmd("sendplayerdata", "set to false to disable sending player to data to clients. Default: true","Example: /vse sendplayerdata true"));
+		addCommand(new Cmd("creeperradius", "type false to disable or type a number to change the radius. Default: 1.75","Example: /vse creeperradius 1.75"));
+		addCommand(new Cmd("bow", "Sets the multiplier for bow damage of vive users. Default: 2","Example: /vse bow 2"));
+		addCommand(new Cmd("checkforupdate", "Checked for an update every time an OP joins the server","Example: /vse checkforupdate true"));
+		addCommand(new Cmd("set", "Allows Editing the plugin config ingame. May need to restart server to take effect.","Example: /vse set general.vive-only true"));
+		addCommand(new Cmd("list", "Lists all the users using Vivecraft.","Example: /vse list"));
 	}
-	
-	public static ArrayList<Cmd> getCommands(){
+
+	private void addCommand(Cmd cmd) {
+		commands.put(cmd.getCommand().toLowerCase(), cmd);
+	}
+
+	public static Map<String, Cmd> getCommands(){
 		return commands;
 	}
 
 	@SuppressWarnings("rawtypes")
 	@Override
-	public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {
+	public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
 		if (sender instanceof Player){
 			Player player = (Player) sender;
 			if (args.length >= 1) {
-				String command = args[0].toLowerCase();
+				Cmd cmd = commands.get(args[0].toLowerCase());
 				//
-				if (command.equals("vive-only") && sender.isOp()) {
+				if(cmd == null) {
+					sendMessage("Unknown command", player);
+					return true;
+				}
+
+				if(!sender.hasPermission(cmd.getPermission())) {
+					sendMessage("You don't have the permission to execute this command!", player);
+					return true;
+				}
+
+				if(cmd.getCommand().equals("vive-only")) {
 					if (args.length >= 2) {
 						if (args[1].toLowerCase().equals("true")) {
 							plugin.getConfig().set("vive-only.enabled", true);
@@ -64,7 +78,7 @@ public class ViveCommand implements CommandExecutor {
 					plugin.saveConfig();
 				} else
 			    //
-				if(command.equals("sendplayerdata") && sender.isOp()){
+				if(cmd.getCommand().equals("sendplayerdata")){
 					if(args.length >= 2){
 						if(args[1].toLowerCase().equals("true")){
 							plugin.getConfig().set("SendPlayerData.enabled", true);
@@ -78,7 +92,7 @@ public class ViveCommand implements CommandExecutor {
 					}
 				}else
 				//
-				if(command.equals("creeperradius") && sender.isOp()){
+				if(cmd.getCommand().equals("creeperradius")){
 					if(args.length >= 2){
 						if(args[1].toLowerCase().equals("true")){
 							plugin.getConfig().set("CreeperRadius.enabled", true);
@@ -99,7 +113,7 @@ public class ViveCommand implements CommandExecutor {
 					}
 				}else
 				//
-				if (command.equals("waittime") && sender.isOp()) {
+				if(cmd.getCommand().equals("waittime")) {
 					if (args.length >= 2) {
 						try {
 							plugin.getConfig().set("vive-only.waittime", Integer.parseInt(args[1]));
@@ -113,7 +127,7 @@ public class ViveCommand implements CommandExecutor {
 					plugin.saveConfig();
 				} else
 				//
-				if (command.equals("bow") && sender.isOp()) {
+				if(cmd.getCommand().equals("bow")) {
 					if (args.length >= 2) {
 						try {
 							plugin.getConfig().set("bow.multiplier", Integer.parseInt(args[1]));
@@ -127,7 +141,7 @@ public class ViveCommand implements CommandExecutor {
 					plugin.saveConfig();
 				} else
 				//
-				if(command.equals("list")){
+				if(cmd.getCommand().equals("list")){
 					Iterator it = VSE.vivePlayers.entrySet().iterator();
 					int size = VSE.vivePlayers.size();
 					int total = plugin.getServer().getOnlinePlayers().size();		
@@ -149,7 +163,7 @@ public class ViveCommand implements CommandExecutor {
 					
 				}else
 				//
-				if(command.equals("set") && sender.isOp()){
+				if(cmd.getCommand().equals("set")){
 					if (args.length >= 3) {
 						String config = args[1];
 						if(plugin.getConfig().get(config) != null){
@@ -179,13 +193,13 @@ public class ViveCommand implements CommandExecutor {
 					}
 				}else
 				//
-				if (command.equals("version")) {
+				if (cmd.getCommand().equals("version")) {
 					PluginDescriptionFile pdf = plugin.getDescription();
 					String version = pdf.getVersion();
 					sendMessage("Version: " + version, player);
 				} else
 				//	
-				if(command.equals("checkforupdate")){
+				if(cmd.getCommand().equals("checkforupdate")){
 					if(args.length >= 2){
 						if(args[1].toLowerCase().equals("true")){
 							plugin.getConfig().set("checkforupdate.enabled", true);
@@ -199,22 +213,18 @@ public class ViveCommand implements CommandExecutor {
 					}
 				}else
 				//
-				if (command.equals("help")) {
+				if(cmd.getCommand().equals("help")) {
 										
 					player.sendMessage(ChatColor.BLUE + "-------------- " + ChatColor.GRAY + "VSE Commands" + ChatColor.BLUE + " --------------");
-					for (Cmd cm : commands) {
-						
-						TextComponent tc = new TextComponent();
-			            tc.setText(ChatColor.BLUE + cm.getCommand() + ": " + ChatColor.WHITE + cm.getDescription());
-			            tc.setHoverEvent(new HoverEvent(net.md_5.bungee.api.chat.HoverEvent.Action.SHOW_TEXT, new ComponentBuilder(cm.getHoverText()).color(ChatColor.BLUE).create()));
-			            player.spigot().sendMessage(tc);
+					for (Cmd cm : commands.values()) {
+						if (sender.hasPermission(cm.getPermission())) {
+							TextComponent tc = new TextComponent();
+							tc.setText(ChatColor.BLUE + cm.getCommand() + ": " + ChatColor.WHITE + cm.getDescription());
+							tc.setHoverEvent(new HoverEvent(net.md_5.bungee.api.chat.HoverEvent.Action.SHOW_TEXT, new ComponentBuilder(cm.getHoverText()).color(ChatColor.BLUE).create()));
+							player.spigot().sendMessage(tc);
+						}
 					}
 
-				} else {
-					if(!sender.isOp()){
-						sendMessage("You must be OP to use these commands", player);
-					}else
-					sendMessage("Unknown command", player);
 				}
 				if(sender.isOp()) plugin.saveConfig();
 			}else{

--- a/src/org/vivecraft/listeners/VivecraftNetworkListener.java
+++ b/src/org/vivecraft/listeners/VivecraftNetworkListener.java
@@ -59,6 +59,10 @@ public class VivecraftNetworkListener implements PluginMessageListener {
 			return;
 		}
 
+		if(!sender.hasPermission("vive.use")) {
+			return;
+		}
+
 		byte[] data = Arrays.copyOfRange(payload, 1, payload.length);
 		switch (disc){
 		case CONTROLLER0DATA:
@@ -111,7 +115,7 @@ public class VivecraftNetworkListener implements PluginMessageListener {
 					byteArrayOutputStream.write(1); // climbey allowed
 
 					String mode = vse.getConfig().getString("climbey.blockmode","none");
-					if(!sender.hasPermission(vse.getConfig().getString("permissions.climbperm"))){
+					if(!sender.hasPermission("vive.climbanywhere")){
 						if(mode.trim().equalsIgnoreCase("include"))
 							byteArrayOutputStream.write(1);
 						else if(mode.trim().equalsIgnoreCase("exclude"))


### PR DESCRIPTION
This adds permissions to all commands (default to the previous op value besides the checkforupdate one which was changed to op too as players should not be able to change that value in the config...) and one for using the server integration. (`vive.use`, allowed by default so it behaves like before) Also moved the climb bypass permission to the plugin.yml to actually be registered properly. (Default is the same as before: op)

Also use alias for the command instead of registering it twice, update old server version in build.gradle and add all permissions to readme.