### PR TITLE
Allow bypass of VR only with permission

### DIFF
--- a/src/org/vivecraft/VSE.java
+++ b/src/org/vivecraft/VSE.java
@@ -418,7 +418,7 @@ public class VSE extends JavaPlugin implements Listener {
 
 					if(kick) {
 						if (getConfig().getBoolean("general.vive-only")) {
-							if (getConfig().getBoolean("general.allow-op") == false || !p.isOp()) {
+							if (!getConfig().getBoolean("general.allow-op") || !p.isOp() || !p.hasPermission("vivecraft.bypass")) {
 								getLogger().info(p.getName() + " " + "got kicked for not using Vivecraft");
 								p.kickPlayer(getConfig().getString("general.vive-only-kickmessage"));
 							}						


### PR DESCRIPTION
This would allow for server owners to give certain players a permission node to bypass VR only without having to give them OP status

Closes #70 